### PR TITLE
Removed the need for JS, added CSS

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,8 +6,7 @@
   "description": "Modifies the CSS and HTML of Allo for Web wrapper",
  
   "content_scripts": [{
-    "css": ["styles.css"],
-    "js": ["content.js"],
+    "css": ["style.css"],
     "matches": ["https://allo.google.com/web"]
   }]
  

--- a/style.css
+++ b/style.css
@@ -1,0 +1,11 @@
+#composer.messages-view { bottom: 0px!important; }
+#compose.compose-bar {
+	margin: 0px!important;
+	max-width: 100%!important;
+	width: 100%!important;
+	border-radius: 0px!important; }
+#container.user-media-message { box-shadow: 0 1px 2px rgba(46, 58, 59, 0.25)!important; }
+#outer.scrolling-messages-list, #inner.scrolling-messages-list { max-width: 100%!important; }
+wireball-app {
+	--conversations-width-full: 300px!important;
+    --info-width: 300px!important; }


### PR DESCRIPTION
JS won’t be needed just yet, for now overriding some annoying CSS
styles in Allo should be enough. Adjusting the positioning and width of
the Input Field to make it more flat and less “hovery”. Also toned back
the drop shadows on pictures and files sent in chats. Again, I prefer
less “hover”. Also forces some elements to maintain a 100% responsive
width.