### PR TITLE
Dark Mode Progress Begins

### DIFF
--- a/darkMode.js
+++ b/darkMode.js
@@ -1,0 +1,35 @@
+document.getElementById("leftBar").style.borderRight = "1px solid #444442";
+document.getElementById("leftBar").style.backgroundColor = "#34373c";
+document.getElementById("library").style.borderTop = "#444442";
+document.getElementById("library").style.borderBottom = "#444442";
+document.getElementById("menu").style.backgroundColor = "#34373c";
+document.getElementById("chip").style.backgroundColor = "transparent";
+document.getElementById("textarea").style.color = "#ffffff";
+document.getElementById("contentContainer").style.backgroundColor = "#141518";
+document.getElementById("startChatButtonString").style.color = "#ffffff";
+document.getElementById("compose").style.backgroundColor = "#34373c";
+document.getElementById("compose").style.borderTop = "1px solid #444442";
+document.getElementById("conversationName").style.color = "#ffffff";
+
+var conversationHeader = document.getElementsByClassName('conversationHeader');
+for(var i = 0; i < conversationHeader.length; i++) {
+    conversationHeader[i].style.backgroundColor = "#34373c";
+}
+
+var composebar = document.getElementsByClassName('compose-bar');
+for(var i = 0; i < composebar.length; i++) {
+    composebar[i].style.backgroundColor = "#34373c";
+}
+
+var conversationsview = document.getElementsByClassName('conversations-view');
+for(var i = 0; i < conversationsview.length; i++) {
+    conversationsview[i].style.backgroundColor = "#34373c";
+    conversationsview[i].style.color = "#ffffff";
+}
+
+document.getElementById("startChatButton").onmouseover = function() {
+    this.style.backgroundColor = "#404348";
+}
+document.getElementById("startChatButton").onmouseout = function() {
+    this.style.backgroundColor = "#34373c";
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
   "manifest_version": 2,
-  "name": "ReStyle for AlloWeb",
-  "version": "0.1.0",
-  "description": "Modifies and helps improve on Allo for Web's styles.",
+  "name": "ReStyle for Allo",
+  "version": "0.1.2",
+  "description": "A Chrome Extension aimed at modifying and improving on Allo for Web's user-interface.",
   "permissions": [
-    "tabs", "<all_urls>","storage","browsingData"
+    "tabs", "https://allo.google.com/web","storage"
   ],
   "icons": { 
     "16":"images/icon-32.png", 

--- a/popup.html
+++ b/popup.html
@@ -44,6 +44,10 @@
   </div>
   <div class="content">
     <label>
+      <input type="checkbox" id="darkMode" value="">
+      Dark Mode
+    </label>
+    <label>
       <input type="checkbox" id="disableSticker" value="" disabled>
       Disable Stickers
     </label>
@@ -51,8 +55,7 @@
       <input type="checkbox" id="disableEmoji" value="" disabled>
       Disable Emoji
     </label>
-    <div id="status"></div>
-    <button id="save" disabled>Save Settings</button>
+    <button id="save" >Save Settings</button>
   </div>
   <script src="popup.js"></script>
 </body>

--- a/popup.js
+++ b/popup.js
@@ -1,23 +1,49 @@
 function save_options() {
-  var disableSticker = document.getElementById('disableSticker').checked;
+  var darkMode = document.getElementById('darkMode').checked;
   chrome.storage.sync.set({
-    disableSticker: disableSticker
+    darkMode: darkMode
   }, 
   function() {
-    var status = document.getElementById('status');
+    var status = document.getElementById('save');
+	if(document.getElementById('darkMode').checked){
+		chrome.tabs.executeScript({
+			file: 'darkMode.js'
+		  }); 
+		}else{
+	  chrome.tabs.executeScript({
+	    file: 'false.js'
+	  }); 
+	}   
     status.textContent = 'Options saved.';
     setTimeout(function() {
-      status.textContent = '';
-    }, 150);
+      status.textContent = 'Save Settings';
+    }, 1250);
+	setTimeout(function(){
+	   window.close(); 
+	}, 1250);
   });
 }
 function load_options() {
   chrome.storage.sync.get({
-    disableSticker: false
+    darkMode: false
   }, function(items) {
     var status = document.getElementById('status');
-    document.getElementById('disableSticker').checked = items.disableSticker;
+    document.getElementById('darkMode').checked = items.darkMode;
+	if(document.getElementById('darkMode').checked){
+		chrome.tabs.executeScript({
+			file: 'darkMode.js'
+		  }); 
+		}else{
+	  chrome.tabs.executeScript({
+	    file: 'false.js'
+	  }); 
+	}
   });
 }
+
+window.onload=function(){
+     console.log("page load!");
+}
+
 document.addEventListener('DOMContentLoaded', load_options);
 document.getElementById('save').addEventListener('click', save_options);

--- a/style.css
+++ b/style.css
@@ -10,11 +10,12 @@ wireball-app {
 	max-width: 100%!important;
 	width: 100%!important;
 	box-shadow: none!important;
-	border-top: 1px solid #e1e1e1!important;
 	border-radius: 0px!important; }
+.stacked.compose-bar #actions.compose-bar { border-radius: 0px!important; }
 #container.user-media-message, .conversationHeader.wireball-app { 
 	box-shadow: 0 1px 2px rgba(46, 58, 59, 0.25)!important; }
 #outer.scrolling-messages-list, #inner.scrolling-messages-list { 
 	max-width: 100%!important; }
 .sendIcon.compose-bar { 
-	margin: 0 16px 0 2px!important; }
+	padding: 13px;
+	margin: 0 12px 0 2px!important; }


### PR DESCRIPTION
Added in a Dark Mode Option to popup.html, currently it's overridng a
handful of polymer styles to acheive a dark theme. It's stil a WIP, but
currently works. To activate it, it's kind of weird:

Click the extension icon in your browser bar, enable the Dark Mode and
then hit Save Settings. Currently, to revert back to normal, you must
uncheck dark mode, hit settings, and then refresh.